### PR TITLE
Remove Microsoft.Web.Infrastructure reference from BlogEngine.Core

### DIFF
--- a/BlogEngine/BlogEngine.Core/BlogEngine.Core.csproj
+++ b/BlogEngine/BlogEngine.Core/BlogEngine.Core.csproj
@@ -81,10 +81,6 @@
     <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>..\..\lib\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\lib\razor\Microsoft.Web.Infrastructure.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>


### PR DESCRIPTION
The reference is currently broken and does not appear to be required.

Note: Microsoft.Web.Infrastructure is referenced in the BlogEngine.NET project.