### PR TITLE
Correct DynamicQuery nuget package reference in BlogEngine.Core

### DIFF
--- a/BlogEngine/BlogEngine.Core/BlogEngine.Core.csproj
+++ b/BlogEngine/BlogEngine.Core/BlogEngine.Core.csproj
@@ -75,7 +75,7 @@
     <Reference Include="BlogML">
       <HintPath>..\..\lib\blogml\BlogML.dll</HintPath>
     </Reference>
-    <Reference Include="Dynamic">
+    <Reference Include="Dynamic, Version=1.0.0.0, Culture=neutral, PublicKeyToken=68293a411f0cabcc, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamicQuery.1.0\lib\35\Dynamic.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib">
@@ -416,7 +416,6 @@
   <ItemGroup>
     <Compile Include="Web\HttpHandlers\JavaScriptHandler.cs" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>

--- a/BlogEngine/BlogEngine.Core/packages.config
+++ b/BlogEngine/BlogEngine.Core/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="DynamicQuery" version="1.0" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="NuGet.Core" version="2.8.2" targetFramework="net45" />


### PR DESCRIPTION
The DynamicQuery nuget package was not included in the BlogEngine.Core packages.config.