### PR TITLE
A fix in TagCloud.cs

### DIFF
--- a/BlogEngine/BlogEngine.Core/Data/Services/TagCloud.cs
+++ b/BlogEngine/BlogEngine.Core/Data/Services/TagCloud.cs
@@ -87,6 +87,7 @@ namespace BlogEngine.Core.Data.Services
         private void SortList()
         {
             var dic = CreateRawList();
+            if (dic.IsEmpty()) return;
             var max = dic.Values.Max();
 
             var currentTagCount = 0;


### PR DESCRIPTION
Enumerable.Max() will throw an exception if the sequence is empty.