### PR TITLE
Fixed errors in the translation of "LangDirection"

### DIFF
--- a/BlogEngine/BlogEngine.NET/App_GlobalResources/labels.cs.resx
+++ b/BlogEngine/BlogEngine.NET/App_GlobalResources/labels.cs.resx
@@ -1976,7 +1976,7 @@
     <value>Vyprázdnit log soubor</value>
   </data>
   <data name="LangDirection" xml:space="preserve">
-    <value>zleva doprava</value>
+    <value>ltr</value>
   </data>
   <data name="apmlDescription" xml:space="preserve">
     <value>Vložte URL vašeho webu nebo APML dokumentu</value>

--- a/BlogEngine/BlogEngine.NET/App_GlobalResources/labels.zh-CN.resx
+++ b/BlogEngine/BlogEngine.NET/App_GlobalResources/labels.zh-CN.resx
@@ -2825,8 +2825,7 @@
     <comment>Justify</comment>
   </data>
   <data name="LangDirection" xml:space="preserve">
-    <value>从左向右</value>
-    <comment>ltr</comment>
+    <value>ltr</value>
   </data>
   <data name="lastUpdate" xml:space="preserve">
     <value>最近更新</value>

--- a/BlogEngine/BlogEngine.NET/Custom/Themes/Standard/site.master
+++ b/BlogEngine/BlogEngine.NET/Custom/Themes/Standard/site.master
@@ -73,7 +73,7 @@
             <div class="container">
                 <p class="copyright float-left">
                     <span>Copyright &copy; <%=DateTime.Now.Year %> - <a href="<%=Utils.AbsoluteWebRoot %>"><%=BlogSettings.Instance.Name %></a></span>
-                    <span>Powered by <a href="http://dotnetblogengine.net" target="_blank" title="BlogEgine.NET <%=BlogSettings.Instance.Version() %>">BlogEngine.NET</a> </span>
+                    <span>Powered by <a href="http://dotnetblogengine.net" target="_blank" title="BlogEngine.NET <%=BlogSettings.Instance.Version() %>">BlogEngine.NET</a></span>
                 </p>
                 <ul class="float-right list-unstyled social-network">
                     <li><a href="[CUSTOMFIELD|THEME|Standard|Facebook Account|/]" rel="external nofollow"><i class="icon-facebook"></i></a></li>


### PR DESCRIPTION
This is not a translation error.

"LangDirection" can only have two values, "ltr" or "rtl". "ltr / rtl" used to indicate the direction of language, can not be translated into local languages. Bug in some language files, "ltr" and "rtl" are translated into local languages, so I fix it.