### PR TITLE
Update widgetController.js

### DIFF
--- a/BlogEngine/BlogEngine.NET/admin/app/custom/widgets/widgetController.js
+++ b/BlogEngine/BlogEngine.NET/admin/app/custom/widgets/widgetController.js
@@ -42,7 +42,7 @@
 
     $scope.loadEditForm = function (id, name, title, zone) {
         var sharedSrc = SiteVars.RelativeWebRoot + "Custom/Widgets/common.cshtml";
-        var customSrc = SiteVars.RelativeWebRoot + "Custom/Widgets/" + name + "/edit.cshtml?id="+ id;
+        var customSrc = SiteVars.RelativeWebRoot + "Custom/Widgets/" + name + "/edit.cshtml";
 
 
         $scope.editId = id;
@@ -55,7 +55,7 @@
 
         $.ajax({
             type: 'HEAD',
-            url: customSrc,
+            url: customSrc + "?id=" + id,
             async: false,
             success: function () {
                 $scope.editSrc = customSrc + "?id=" + id + "&zone=" + zone;

--- a/BlogEngine/BlogEngine.NET/admin/app/custom/widgets/widgetController.js
+++ b/BlogEngine/BlogEngine.NET/admin/app/custom/widgets/widgetController.js
@@ -42,7 +42,8 @@
 
     $scope.loadEditForm = function (id, name, title, zone) {
         var sharedSrc = SiteVars.RelativeWebRoot + "Custom/Widgets/common.cshtml";
-        var customSrc = SiteVars.RelativeWebRoot + "Custom/Widgets/" + name + "/edit.cshtml";
+        var customSrc = SiteVars.RelativeWebRoot + "Custom/Widgets/" + name + "/edit.cshtml?id="+ id;
+
 
         $scope.editId = id;
         $scope.editTitle = title;


### PR DESCRIPTION
[Initially logged on CodePlex but this is a better home ](https://blogengine.codeplex.com/workitem/12626)

I have attempted an upgrade of a **multiblog** instance backed by **MS SQL** of BlogEngine 3.2 to 3.3.  

1. I used the new codeplex binary distribution
2. Ran the upgrade SQL scripts to alter the schema and the delete script to remove the old widgets
3. Edited the web.config to point at my SQL DB for content, users and roles

I could access all my blogs, post etc. As expected there were no widgets show (as they have been deleted). So I....

1. Login as an admin
2. Added the widgets via drag and drop, they appear on the pages, but with default options

If I try to edit a widget to alter the settings the popup dialog is the right size but empty.

If I checked the server logs I see the error 

`The parameterized query '(@blogid nvarchar(36),@etype int,@eid nvarchar(4000))SELECT Sett' expects the parameter '@eid', which was not supplied. `

I have had a look at the source for the [widget editors controller](https://github.com/rxtur/BlogEngine.NET/blob/master/BlogEngine/BlogEngine.NET/admin/app/custom/widgets/widgetController.js) and it seems the widget id is not being set on the Url as a query string entry. If I alter the line to 

`var customSrc = SiteVars.RelativeWebRoot + "Custom/Widgets/" + name + "/edit.cshtml?id="+ id;`
 
It works, but I am not sure of any knock on effects, not sure if this is the real cause of the issue.