### PR TITLE
Fixed Uri encoding in rss feed (important for urls containing international letters)

### DIFF
--- a/BlogEngine/BlogEngine.Core/Services/Syndication/SyndicationGenerator.cs
+++ b/BlogEngine/BlogEngine.Core/Services/Syndication/SyndicationGenerator.cs
@@ -673,7 +673,7 @@ namespace BlogEngine.Core
             }
 
             writer.WriteElementString("description", content);
-            writer.WriteElementString("link", publishable.AbsoluteLink.ToString());
+            writer.WriteElementString("link", publishable.AbsoluteLink.AbsoluteUri);
 
             // ------------------------------------------------------------
             // Write enclosure tag for podcasting support

--- a/BlogEngine/BlogEngine.Core/Services/Syndication/SyndicationGenerator.cs
+++ b/BlogEngine/BlogEngine.Core/Services/Syndication/SyndicationGenerator.cs
@@ -479,7 +479,7 @@ namespace BlogEngine.Core
             writer.WriteEndElement();
 
             writer.WriteStartElement("link");
-            writer.WriteAttributeString("href", publishable.AbsoluteLink.ToString());
+            writer.WriteAttributeString("href", publishable.AbsoluteLink.AbsoluteUri);
             writer.WriteEndElement();
 
             writer.WriteStartElement("author");
@@ -498,7 +498,7 @@ namespace BlogEngine.Core
 
             writer.WriteStartElement("link");
             writer.WriteAttributeString("rel", "related");
-            writer.WriteAttributeString("href", String.Concat(publishable.AbsoluteLink.ToString(), "#comment"));
+            writer.WriteAttributeString("href", String.Concat(publishable.AbsoluteLink.AbsoluteUri, "#comment"));
             writer.WriteEndElement();
 
             // ------------------------------------------------------------
@@ -604,7 +604,7 @@ namespace BlogEngine.Core
                 "wfw",
                 "comment",
                 "http://wellformedweb.org/CommentAPI/",
-                String.Concat(publishable.AbsoluteLink.ToString(), 
+                String.Concat(publishable.AbsoluteLink.AbsoluteUri, 
                 "#comment"));
             writer.WriteElementString(
                 "wfw",
@@ -697,7 +697,7 @@ namespace BlogEngine.Core
             if (post != null)
             {
                 writer.WriteElementString(
-                    "comments", String.Concat(publishable.AbsoluteLink.ToString(),
+                    "comments", String.Concat(publishable.AbsoluteLink.AbsoluteUri,
 					"#comment"));
             }
 
@@ -791,7 +791,7 @@ namespace BlogEngine.Core
                 "wfw",
                 "comment",
                 "http://wellformedweb.org/CommentAPI/",
-                String.Concat(publishable.AbsoluteLink.ToString(),
+                String.Concat(publishable.AbsoluteLink.AbsoluteUri,
 				"#comment"));
             writer.WriteElementString(
                 "wfw",

--- a/BlogEngine/BlogEngine.Core/Web/HttpHandlers/SiteMap.cs
+++ b/BlogEngine/BlogEngine.Core/Web/HttpHandlers/SiteMap.cs
@@ -52,7 +52,7 @@
                 foreach (var post in Post.Posts.Where(post => post.IsVisibleToPublic))
                 {
                     writer.WriteStartElement("url");
-                    writer.WriteElementString("loc", post.AbsoluteLink.ToString());
+                    writer.WriteElementString("loc", post.AbsoluteLink.AbsoluteUri.ToString());
                     writer.WriteElementString(
                         "lastmod", post.DateModified.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
                     writer.WriteElementString("changefreq", "monthly");
@@ -63,7 +63,7 @@
                 foreach (var page in Page.Pages.Where(page => page.IsVisibleToPublic))
                 {
                     writer.WriteStartElement("url");
-                    writer.WriteElementString("loc", page.AbsoluteLink.ToString());
+                    writer.WriteElementString("loc", page.AbsoluteLink.AbsoluteUri);
                     writer.WriteElementString(
                         "lastmod", page.DateModified.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
                     writer.WriteElementString("changefreq", "monthly");

--- a/BlogEngine/BlogEngine.Core/Web/HttpHandlers/TrackbackHandler.cs
+++ b/BlogEngine/BlogEngine.Core/Web/HttpHandlers/TrackbackHandler.cs
@@ -133,7 +133,7 @@
                 postId.Length == 36)
             {
                 post = Post.GetPost(new Guid(postId));
-                this.ExamineSourcePage(url, post.AbsoluteLink.ToString());
+                this.ExamineSourcePage(url, post.AbsoluteLink.AbsoluteUri);
                 var containsHtml = !string.IsNullOrEmpty(excerpt) &&
                                    (RegexHtml.IsMatch(excerpt) || RegexHtml.IsMatch(title) ||
                                     RegexHtml.IsMatch(blogName));


### PR DESCRIPTION
See
http://stackoverflow.com/questions/7624987/whats-the-difference-between-uri-tostring-and-uri-absoluteuri