### PR TITLE
Fix styles and attributes in all widgets to be identical to the ones …

### DIFF
--- a/BlogEngine/BlogEngine.NET/Custom/Widgets/Administration/widget.cshtml
+++ b/BlogEngine/BlogEngine.NET/Custom/Widgets/Administration/widget.cshtml
@@ -10,9 +10,9 @@
 }
 @if (Security.IsAuthenticated)
 {
-    <div class="widget administration">
-        <h4 class="widget-header">@title</h4>
-        <div class="widget-content">
+    <div class="Widget administration" id="widget@(Model.Id)">
+        <h4 class="WidgetHeader">@title</h4>
+        <div class="WidgetContent">
             <ul class="toprounded" id="uxMenu_ulMenu">
                 @if (Security.IsAuthorizedTo(Rights.ViewDashboard))
                 {

--- a/BlogEngine/BlogEngine.NET/Custom/Widgets/AuthorList/widget.cshtml
+++ b/BlogEngine/BlogEngine.NET/Custom/Widgets/AuthorList/widget.cshtml
@@ -8,11 +8,11 @@
     IEnumerable<MembershipUser> users = Membership.GetAllUsers()
         .Cast<MembershipUser>().ToList().OrderBy(a => a.UserName);
 }
-<div class="widget authorlist">
-    <h4 class="widget-header">
+<div class="Widget authorlist" id="widget@(Model.Id)">
+    <h4 class="WidgetHeader">
         @title
     </h4>
-    <div class="widget-content">
+    <div class="WidgetContent">
         <ul id="authorlist" class="authorlist">
             @foreach (var user in users)
             {

--- a/BlogEngine/BlogEngine.NET/Custom/Widgets/BlogList/widget.cshtml
+++ b/BlogEngine/BlogEngine.NET/Custom/Widgets/BlogList/widget.cshtml
@@ -3,11 +3,11 @@
     var title = Model.Title;
     var blogs = Blog.Blogs.Where(b => b.IsActive).ToList();
 }
-<div class="widget bloglist">
-    <h4 class="widget-header">
+<div class="Widget bloglist id="widget@(Model.Id)"">
+    <h4 class="WidgetHeader">
         @title
     </h4>
-    <div class="widget-content">
+    <div class="WidgetContent">
         <ul>
             @foreach (var blog in blogs)
             {

--- a/BlogEngine/BlogEngine.NET/Custom/Widgets/BlogRoll/widget.cshtml
+++ b/BlogEngine/BlogEngine.NET/Custom/Widgets/BlogRoll/widget.cshtml
@@ -7,9 +7,9 @@
     var imgPath = Utils.ApplicationRelativeWebRoot + "Content/images/blog";
     var opmlPath = Utils.ApplicationRelativeWebRoot + "opml.axd";
 }
-<div class="widget blogroll">
-    <h4 class="widget-header">@title</h4>
-    <div class="widget-content">
+<div class="Widget blogroll" id="widget@(Model.Id)">
+    <h4 class="WidgetHeader">@title</h4>
+    <div class="WidgetContent">
         @if (rolls != null)
         {
         <ul class="xoxo">

--- a/BlogEngine/BlogEngine.NET/Custom/Widgets/CategoryList/widget.cshtml
+++ b/BlogEngine/BlogEngine.NET/Custom/Widgets/CategoryList/widget.cshtml
@@ -4,9 +4,9 @@
     var title = Model.Title;
     var dic = CategoryList.SortCategories();
 }
-<div class="widget categorylist">
-    <h4 class="widget-header">@title</h4>
-    <div class="widget-content">
+<div class="Widget categorylist" id="widget@(Model.Id)">
+    <h4 class="WidgetHeader">@title</h4>
+    <div class="WidgetContent">
         <ul id="categorylist">
             @foreach (var cat in dic.Values)
             {

--- a/BlogEngine/BlogEngine.NET/Custom/Widgets/CommentList/widget.cshtml
+++ b/BlogEngine/BlogEngine.NET/Custom/Widgets/CommentList/widget.cshtml
@@ -23,9 +23,9 @@
         display: inline !important;
     }
 </style>
-<div class="widget recentcomments">
-    <h4 class="widget-header">@Model.Title</h4>
-    <div class="widget-content">
+<div class="Widget recentcomments" id="widget@(Model.Id)">
+    <h4 class="WidgetHeader">@Model.Title</h4>
+    <div class="WidgetContent">
         <ul id="recentComments" class="recentcomments">
             @if (list.Count > 0)
             {

--- a/BlogEngine/BlogEngine.NET/Custom/Widgets/LinkList/widget.cshtml
+++ b/BlogEngine/BlogEngine.NET/Custom/Widgets/LinkList/widget.cshtml
@@ -3,9 +3,9 @@
     var linkList = new LinkList(Model.Id);
     var links = linkList.GetLinks();
 }
-<div class="widget linklist">
-    <h4 class="widget-header">@Model.Title</h4>
-    <div class="widget-content">
+<div class="Widget linklist" id="widget@(Model.Id)">
+    <h4 class="WidgetHeader">@Model.Title</h4>
+    <div class="WidgetContent">
         <ul id="linkList" class="linklist">
         @foreach (var link in links)
         {

--- a/BlogEngine/BlogEngine.NET/Custom/Widgets/MonthList/widget.cshtml
+++ b/BlogEngine/BlogEngine.NET/Custom/Widgets/MonthList/widget.cshtml
@@ -6,9 +6,9 @@
     var cnt = 0;
     var cls = "open";
 }
-<div class="widget monthlist">
-    <h4 class="widget-header">@title</h4>
-    <div class="widget-content">
+<div class="Widget monthlist" id="widget@(Model.Id)">
+    <h4 class="WidgetHeader">@title</h4>
+    <div class="WidgetContent">
         <ul id="monthList">
             @foreach (KeyValuePair<int, List<MonthItem>> y in years)
             {
@@ -17,7 +17,7 @@
             cnt = cnt + 1;
             cls = cnt > 1 ? "close" : "open";
             <li onclick="@tgl" class="year">@y.Key
-                <ul id="@yId" class="@cls">
+                <ul id="widget@yId" class="@cls">
                     @foreach (var item in y.Value)
                     {
                     <li><a href="@item.Url/default">@item.Title</a> (@item.Count)</li>

--- a/BlogEngine/BlogEngine.NET/Custom/Widgets/Newsletter/widget.cshtml
+++ b/BlogEngine/BlogEngine.NET/Custom/Widgets/Newsletter/widget.cshtml
@@ -24,9 +24,9 @@
         showForm = true;
     }
 }
-<div class="widget newsletter">
-    <h4 class="widget-header">@Model.Title</h4>
-    <div class="widget-content" style="padding: 20px">
+<div class="Widget newsletter" id="widget@(Model.Id)">
+    <h4 class="WidgetHeader">@Model.Title</h4>
+    <div class="WidgetContent" style="padding: 20px">
         @if (showThanks)
         {
         <div style="padding: 20px 40px" id="newsletterthanks">

--- a/BlogEngine/BlogEngine.NET/Custom/Widgets/PageList/widget.cshtml
+++ b/BlogEngine/BlogEngine.NET/Custom/Widgets/PageList/widget.cshtml
@@ -2,9 +2,9 @@
 @{
     var title = Model.Title;
 }
-<div class="widget pagelist">
-    <h4 class="widget-header">@title</h4>
-    <div class="widget-content">
+<div class="Widget pagelist">
+    <h4 class="WidgetHeader">@title</h4>
+    <div class="WidgetContent" id="widget@(Model.Id)">
         <ul>
             @foreach (var page in BlogEngine.Core.Page.Pages.Where(page => page.ShowInList && page.IsVisibleToPublic))
             {

--- a/BlogEngine/BlogEngine.NET/Custom/Widgets/PostList/widget.cshtml
+++ b/BlogEngine/BlogEngine.NET/Custom/Widgets/PostList/widget.cshtml
@@ -70,9 +70,9 @@
         bool.TryParse(settings["showdate"], out showDate);
     }
 }
-<div class="widget postlist">
-    <h4 class="widget-header">@title</h4>
-    <div class="widget-content">
+<div class="Widget postlist" id="widget@(Model.Id)">
+    <h4 class="WidgetHeader">@title</h4>
+    <div class="WidgetContent">
         <ul>
             @if (list.Count == 0)
             {

--- a/BlogEngine/BlogEngine.NET/Custom/Widgets/Search/widget.cshtml
+++ b/BlogEngine/BlogEngine.NET/Custom/Widgets/Search/widget.cshtml
@@ -3,13 +3,13 @@
     var text = Context.Request.QueryString["q"] != null
         ? HttpUtility.HtmlEncode(Context.Request.QueryString["q"])
         : BlogSettings.Instance.SearchDefaultText;
-    var widgetId = Model.Id;
+    var WidgetId = Model.Id;
 }
-<div class="widget search">
-    <div class="widget-content">
+<div class="Widget search" id="widget@(Model.Id)">
+    <div class="WidgetContent">
         <div id="searchbox">
-            <input type="text" style="width: 72% !important" onblur="BlogEngine.searchClear('@text','txt-@widgetId')" onfocus="BlogEngine.searchClear('@text','txt-@widgetId')" onkeypress="if(event.keyCode==13) return BlogEngine.search('@Utils.RelativeWebRoot','txt-@widgetId')" id="txt-@widgetId" value="@text" />
-            <input type="button" onkeypress="BlogEngine.search('@Utils.RelativeWebRoot', 'txt-@widgetId');" onclick="BlogEngine.search('@Utils.RelativeWebRoot', 'txt-@widgetId');" id="searchbutton" value="Search" />
+            <input type="text" style="width: 72% !important" onblur="BlogEngine.searchClear('@text','txt-@WidgetId')" onfocus="BlogEngine.searchClear('@text','txt-@WidgetId')" onkeypress="if(event.keyCode==13) return BlogEngine.search('@Utils.RelativeWebRoot','txt-@WidgetId')" id="txt-@WidgetId" value="@text" />
+            <input type="button" onkeypress="BlogEngine.search('@Utils.RelativeWebRoot', 'txt-@WidgetId');" onclick="BlogEngine.search('@Utils.RelativeWebRoot', 'txt-@WidgetId');" id="searchbutton" value="Search" />
         </div>
     </div>
 </div>

--- a/BlogEngine/BlogEngine.NET/Custom/Widgets/TagCloud/widget.cshtml
+++ b/BlogEngine/BlogEngine.NET/Custom/Widgets/TagCloud/widget.cshtml
@@ -3,9 +3,9 @@
     var cloud = new BlogEngine.Core.Data.Services.TagCloud();
     var tags = cloud.Links();
 }
-<div class="widget tagcloud">
-    <h4 class="widget-header">@title</h4>
-    <div class="widget-content">
+<div class="Widget tagcloud" id="widget@(Model.Id)">
+    <h4 class="WidgetHeader">@title</h4>
+    <div class="WidgetContent">
         <ul>
             @foreach (var tag in tags)
             {

--- a/BlogEngine/BlogEngine.NET/Custom/Widgets/TextBox/widget.cshtml
+++ b/BlogEngine/BlogEngine.NET/Custom/Widgets/TextBox/widget.cshtml
@@ -7,6 +7,6 @@
         txt = HttpUtility.HtmlDecode(settings["content"]);
     }
 }
-<div class="widget textbox">
+<div class="Widget textbox" id="widget@(Model.Id)">
     @Html.Raw(txt)
 </div>


### PR DESCRIPTION
…in previous version:

- "Widget" class should be written in this way, not "widget"
- "WidgetHeader" and "WidgetContent" instead of the new "widget-header" and "widget-content"
- Added the id attribute with "widget" prefix to be totally compatible with the previous version generated HTML

With this changes the HTML generated by widgets is compatible with the HTML generated by the widgets in the previous version (the WebForms-based ones). This is important because a lot of custom made themes stop to work due to the name changes and the lack of id attribute (this is less important).

The new widgets should have the same HTML.
