### PR TITLE
Add support for scripts in the TextBox widget

### DIFF
--- a/BlogEngine/BlogEngine.NET/Custom/Widgets/TextBox/edit.cshtml
+++ b/BlogEngine/BlogEngine.NET/Custom/Widgets/TextBox/edit.cshtml
@@ -45,7 +45,8 @@
             relative_urls: false,
             browser_spellcheck: true,
             paste_data_images: true,
-            encoding: 'xml'
+            encoding: 'xml',
+			extended_valid_elements: 'iframe[src|style|width|height|scrolling|marginwidth|marginheight|frameborder],script[src|type|async]'
         });
     </script>
 </head>


### PR DESCRIPTION
The previous TextBox widget allowed to include scripts in its contents so that you could use it as a means to add some interactive content in every page in a simple way. The new version doesn't allow this by default.

I've added a line to the TinyMCE HTM Editor so that it allows iframes and scripts in its contents.