### PR TITLE
Validate Site.Master exists in theme folder

### DIFF
--- a/BlogEngine/BlogEngine.Core/Web/Controls/BlogBasePage.cs
+++ b/BlogEngine/BlogEngine.Core/Web/Controls/BlogBasePage.cs
@@ -279,8 +279,14 @@
                     return path;
             }
 
-            return string.Format("{0}Custom/Themes/{1}/site.master", Utils.ApplicationRelativeWebRoot, 
-                BlogSettings.Instance.GetThemeWithAdjustments(null));
+            var siteMaster = string.Format("{0}Custom/Themes/{1}/site.master", Utils.ApplicationRelativeWebRoot, 
+                                            BlogSettings.Instance.GetThemeWithAdjustments(null));
+
+            if (System.IO.File.Exists(Server.MapPath(siteMaster)))
+                return siteMaster;
+            else
+                return string.Format("{0}Custom/Themes/Standard/site.master", Utils.ApplicationRelativeWebRoot);
+
         }
     }
 }


### PR DESCRIPTION
fix so that we check to see if the site.master exists and if not we just roll back to a standard one. This can happen when the site us using a custom theme then the theme is removed. In the current implementation this resulted in a blank page getting rendered. The error handling didn't seem to work.