### PR TITLE
Added Orderby to use the sortorder for page objects in BlogEngine.

### DIFF
--- a/BlogEngine/BlogEngine.Core/Web/Controls/PageMenu.cs
+++ b/BlogEngine/BlogEngine.Core/Web/Controls/PageMenu.cs
@@ -83,7 +83,7 @@ namespace BlogEngine.Core.Web.Controls
         {
             bool returnValue = false;
 
-            foreach (BlogEngine.Core.Page page in BlogEngine.Core.Page.Pages)
+            foreach (BlogEngine.Core.Page page in BlogEngine.Core.Page.Pages.OrderBy(page => page.SortOrder))
             {
                 if (page.ShowInList && page.IsPublished)
                 {


### PR DESCRIPTION
The output of this pagemenu control is not in sync when you give in a sortorder in for pages in the dashboard of BlogEngine.