### PR TITLE
Set XmlResolver syndication.axd

### DIFF
--- a/BlogEngine/BlogEngine.Core/Web/HttpHandlers/SyndicationHandler.cs
+++ b/BlogEngine/BlogEngine.Core/Web/HttpHandlers/SyndicationHandler.cs
@@ -185,7 +185,7 @@
                         client.Encoding = Encoding.Default;
                         using (var stream = client.OpenRead(context.Request.QueryString["apml"]))
                         {
-                            var doc = new XmlDocument();
+                            var doc = new XmlDocument() { XmlResolver = null };
                             if (stream != null)
                             {
                                 doc.Load(stream);


### PR DESCRIPTION
Could do:

`{ XmlResolver = new XmlSafeResolver() }`

But I couldn't think of a valid case to allow external entities.