### PR TITLE
Remove default machineKey

### DIFF
--- a/BlogEngine/BlogEngine.NET/Web.Config
+++ b/BlogEngine/BlogEngine.NET/Web.Config
@@ -89,7 +89,6 @@
     <globalization requestEncoding="utf-8" responseEncoding="utf-8" culture="auto" uiCulture="auto" />
     <httpRuntime targetFramework="4.5" enableVersionHeader="false" useFullyQualifiedRedirectUrl="true" maxRequestLength="16384" executionTimeout="3600" requestLengthDiskThreshold="16384" requestValidationMode="2.0" requestPathInvalidCharacters="&lt;,&gt;,*,\" />
 
-    <machineKey validationKey="D9F7287EFDE8DF4CAFF79011D5308643D8F62AE10CDF30DAB640B7399BF6C57B0269D60A23FBCCC736FC2487ED695512BA95044DE4C58DC02C2BA0C4A266454C" decryptionKey="BDAAF7E00B69BA47B37EEAC328929A06A6647D4C89FED3A7D5C52B12B23680F4" validation="SHA1" decryption="AES" />
     <!--<machineKey validationKey="AutoGenerate,IsolateApps" decryptionKey="AutoGenerate,IsolateApps" validation="SHA1" decryption="AES"/>-->
 
     <authentication mode="Forms">


### PR DESCRIPTION
Remove default machineKey as it is a serious security issue. The default behavior is to let the framework generate a new machineKey on each restart. This will work in most cases. In other edge cases, such as a non-sticky load balancer setup, a machineKey may be used (but not the default one).